### PR TITLE
yahoo_actions fixes

### DIFF
--- a/pandas_datareader/yahoo/actions.py
+++ b/pandas_datareader/yahoo/actions.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from pandas import (concat, DataFrame)
 from pandas_datareader.yahoo.daily import YahooDailyReader
 
@@ -35,7 +37,11 @@ class YahooActionReader(YahooDailyReader):
             # Only do so if splits is nontrivial, which throws ValueError
             # otherwise
             if len(splits) > 0:
-                splits['value'] = splits.apply(lambda x: 1/eval(x['value']), axis=1)  # noqa
+                splits['value'] = splits.apply(lambda x: 1/eval(
+                    compile(x['value'],
+                        '<string>',
+                        'eval',
+                        division.compiler_flag)), axis=1)  # noqa
 
         output = concat([dividends, splits]).sort_index(ascending=False)
 

--- a/pandas_datareader/yahoo/actions.py
+++ b/pandas_datareader/yahoo/actions.py
@@ -32,7 +32,10 @@ class YahooActionReader(YahooDailyReader):
             splits = splits.rename(columns={'Stock Splits': 'value'})
             # Converts fractional form splits (i.e. "2/1") into conversion
             # ratios, then take the reciprocal
-            splits['value'] = splits.apply(lambda x: 1/eval(x['value']), axis=1)  # noqa
+            # Only do so if splits is nontrivial, which throws ValueError
+            # otherwise
+            if len(splits) > 0:
+                splits['value'] = splits.apply(lambda x: 1/eval(x['value']), axis=1)  # noqa
 
         output = concat([dividends, splits]).sort_index(ascending=False)
 


### PR DESCRIPTION
I noticed a couple errant behaviors calling `get_data_yahoo_actions()`:

- it errors if the symbol has no splits in the requested timeframe
- if there are splits in the requested timeframe, `value` ends up `0` in most cases under python 2.7 because of division

This PR fixes both.